### PR TITLE
request module explicitly listed

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "url": "git+https://github.com/Tuxdiver/MMM-Rest.git"
   },
   "dependencies": {
-    "sprintf-js": ""
+    "sprintf-js": "",
+    "request": ""
   }
 }


### PR DESCRIPTION
Installing module fails without this on fresh MagicMirror install. Likely request module was available for modules implicitly earlier?