### PR TITLE
Add ability to create multiple instances of module in one config file

### DIFF
--- a/MMM-Rest.js
+++ b/MMM-Rest.js
@@ -25,7 +25,7 @@ Module.register("MMM-Rest",{
         output: [
             ['The answer','@1']
         ],
-
+	tableID: 1,
 	},
 	// Define required scripts.
 	getStyles: function() {
@@ -225,6 +225,7 @@ Module.register("MMM-Rest",{
                 {
                     id: id,
                     url: section.url
+		    tableID: this.config.tableID
                 }
             );
         }
@@ -246,7 +247,7 @@ Module.register("MMM-Rest",{
 	},
     
     socketNotificationReceived: function(notification, payload) {
-        if (notification === 'MMM_REST_RESPONSE' ) {
+        if (notification === 'MMM_REST_RESPONSE' && payload.tableID == this.config.tableID ) {
             this.debugmsg('received:' + notification);
             if(payload.data && payload.data.statusCode === 200){
                 this.debugmsg("process result:"+payload.id+" data:"+payload.data.body);

--- a/MMM-Rest.js
+++ b/MMM-Rest.js
@@ -225,7 +225,7 @@ Module.register("MMM-Rest",{
                 {
                     id: id,
                     url: section.url,
-		    tableID: this.config.tableID
+		    tableID: this.config.sections
                 }
             );
         }
@@ -247,7 +247,7 @@ Module.register("MMM-Rest",{
 	},
     
     socketNotificationReceived: function(notification, payload) {
-        if (notification === 'MMM_REST_RESPONSE' && payload.tableID == this.config.tableID ) {
+        if (notification === 'MMM_REST_RESPONSE' && payload.tableID == this.config.sections ) {
             this.debugmsg('received:' + notification);
             if(payload.data && payload.data.statusCode === 200){
                 this.debugmsg("process result:"+payload.id+" data:"+payload.data.body);

--- a/MMM-Rest.js
+++ b/MMM-Rest.js
@@ -224,7 +224,7 @@ Module.register("MMM-Rest",{
                 'MMM_REST_REQUEST',
                 {
                     id: id,
-                    url: section.url
+                    url: section.url,
 		    tableID: this.config.tableID
                 }
             );

--- a/MMM-Rest.js
+++ b/MMM-Rest.js
@@ -225,7 +225,7 @@ Module.register("MMM-Rest",{
                 {
                     id: id,
                     url: section.url,
-		    tableID: this.config.sections
+		    tableID: JSON.stringify(this.config.sections)
                 }
             );
         }
@@ -247,7 +247,7 @@ Module.register("MMM-Rest",{
 	},
     
     socketNotificationReceived: function(notification, payload) {
-        if (notification === 'MMM_REST_RESPONSE' && payload.tableID == this.config.sections ) {
+        if (notification === 'MMM_REST_RESPONSE' && payload.tableID == JSON.stringify(this.config.sections) ) {
             this.debugmsg('received:' + notification);
             if(payload.data && payload.data.statusCode === 200){
                 this.debugmsg("process result:"+payload.id+" data:"+payload.data.body);

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ This module collects data via HTTP calls and displays it on your mirror in a tab
 
 
 ## Changelog
-<p>2016-10-27: incompatible changes: the "suffix" and "digits" parameters are removed and replaced by a "format" parameter! Please check your config!
-<p></p>2018-02-02: added ranges to format parameter
-<p></p>2024-03-21: added `tableID` config option to permit multiple instances of the module
+<p>2016-10-27: incompatible changes: the "suffix" and "digits" parameters are removed and replaced by a "format" parameter! Please check your config!</p>
+<p>2018-02-02: added ranges to format parameter</p>
+<p>2024-03-21: added the ability to place multiple instances of the module into config files</p>
 
 ## Known Issues
 - had a problem with remote URLs an AJAX: changed to node_helper.js to collect data
@@ -75,7 +75,7 @@ modules: [
                 ['Kitchen','@3','@4'],
                 ['Fridge','@5'],
             ],
-            tableID: "my first table",
+
 	    },
 	}
 ]
@@ -180,13 +180,6 @@ The following properties can be configured:
 			<td>Log messages to Log.info / console<br>
 				<br><b>Example:</b> <code>true</code>
 				<br><b>Default value:</b> <code>false</code>
-			</td>
-		</tr>
-		<tr>
-			<td valign="top"><code>tableID</code></td>
-			<td>A unique ID for a given instance of the module.  Optional unless you want 2 or more instances of the module in your config.<br>
-				<br><b>Type:</b> Literally anything, as long as it's unique
-				<br><b>Default value:</b> <code>1</code>
 			</td>
 		</tr>
 	</tbody>

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ This module collects data via HTTP calls and displays it on your mirror in a tab
 ![Rest Displays](https://raw.githubusercontent.com/wiki/Tuxdiver/MMM-Rest/images/screenshot.png)
 
 ## Installation
-1. Navigate into your MagicMirror's 'modules' folder and execute 'git clone https://github.com/Tuxdiver/MMM-Rest.git'
-2. cd 'cd MMM-Rest'
-3. Execute 'npm install' to install the node dependencies.
+1. Navigate into your MagicMirror's `modules` folder and execute `git clone https://github.com/Tuxdiver/MMM-Rest.git`
+2. cd `cd MMM-Rest`
+3. Execute `npm install` to install the node dependencies.
 
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ modules: [
                 ['Kitchen','@3','@4'],
                 ['Fridge','@5'],
             ],
+            tableID: "my first table",
 	    },
 	}
 ]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This module collects data via HTTP calls and displays it on your mirror in a tab
 ## Changelog
 2016-10-27: incompatible changes: the "suffix" and "digits" parameters are removed and replaced by a "format" parameter! Please check your config!
 2018-02-02: added ranges to format parameter
+2024-03-21: added `tableID` config option to permit multiple instances of the module
 
 ## Known Issues
 - had a problem with remote URLs an AJAX: changed to node_helper.js to collect data
@@ -178,6 +179,13 @@ The following properties can be configured:
 			<td>Log messages to Log.info / console<br>
 				<br><b>Example:</b> <code>true</code>
 				<br><b>Default value:</b> <code>false</code>
+			</td>
+		</tr>
+		<tr>
+			<td valign="top"><code>tableID</code></td>
+			<td>A unique ID for a given instance of the module.  Optional unless you want 2 or more instances of the module in your config.<br>
+				<br><b>Type:</b> Literally anything, as long as it's unique
+				<br><b>Default value:</b> <code>1</code>
 			</td>
 		</tr>
 	</tbody>

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ This module collects data via HTTP calls and displays it on your mirror in a tab
 
 
 ## Changelog
-2016-10-27: incompatible changes: the "suffix" and "digits" parameters are removed and replaced by a "format" parameter! Please check your config!
-2018-02-02: added ranges to format parameter
-2024-03-21: added `tableID` config option to permit multiple instances of the module
+<p>2016-10-27: incompatible changes: the "suffix" and "digits" parameters are removed and replaced by a "format" parameter! Please check your config!
+<p></p>2018-02-02: added ranges to format parameter
+<p></p>2024-03-21: added `tableID` config option to permit multiple instances of the module
 
 ## Known Issues
 - had a problem with remote URLs an AJAX: changed to node_helper.js to collect data

--- a/node_helper.js
+++ b/node_helper.js
@@ -25,6 +25,7 @@ module.exports = NodeHelper.create({
                     that.sendSocketNotification('MMM_REST_RESPONSE', {
                         id: payload.id,
                         data: response
+                        tableID: payload.tableID
                     });
                 }
             });

--- a/node_helper.js
+++ b/node_helper.js
@@ -24,7 +24,7 @@ module.exports = NodeHelper.create({
                     // console.log("send notification: "+payload.id);
                     that.sendSocketNotification('MMM_REST_RESPONSE', {
                         id: payload.id,
-                        data: response
+                        data: response,
                         tableID: payload.tableID
                     });
                 }


### PR DESCRIPTION
Passed a stringified version of the `sections` variable through the update notifications, then check to make sure that the response notification applies to the given module instance before updating the table.  